### PR TITLE
S1/be user entity refactors

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -42,6 +42,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-h2console'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.security:spring-security-crypto'
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:3.0.2'
 
 
     developmentOnly 'org.springframework.boot:spring-boot-devtools'

--- a/build.gradle
+++ b/build.gradle
@@ -71,6 +71,10 @@ jacocoTestReport {
     }
 }
 
+compileJava {
+    options.compilerArgs << '-parameters'
+}
+
 test {
     useJUnitPlatform()
     testLogging.showStandardStreams = true

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/config/WebConfig.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/config/WebConfig.java
@@ -18,6 +18,8 @@ public class WebConfig implements WebMvcConfigurer {
     public void addInterceptors(InterceptorRegistry registry) {
         registry.addInterceptor(authInterceptor)
                 .addPathPatterns("/**")
-                .excludePathPatterns("/auth/register", "/auth/login");
+                .excludePathPatterns("/auth/register", "/auth/login",
+                        "/swagger-ui/**", "/swagger-ui.html", "/v3/api-docs/**",
+                        "/");
     }
 }

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/config/WebConfig.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/config/WebConfig.java
@@ -1,0 +1,23 @@
+package ch.uzh.ifi.hase.soprafs26.config;
+
+import ch.uzh.ifi.hase.soprafs26.interceptor.AuthInterceptor;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class WebConfig implements WebMvcConfigurer {
+
+    private final AuthInterceptor authInterceptor;
+
+    public WebConfig(AuthInterceptor authInterceptor) {
+        this.authInterceptor = authInterceptor;
+    }
+
+    @Override
+    public void addInterceptors(InterceptorRegistry registry) {
+        registry.addInterceptor(authInterceptor)
+                .addPathPatterns("/**")
+                .excludePathPatterns("/auth/register", "/auth/login");
+    }
+}

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/controller/SkillMapController.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/controller/SkillMapController.java
@@ -32,7 +32,8 @@ public class SkillMapController {
     // 201 - GET /skillmaps - returns only maps the requester is a member of
     @GetMapping
     @ResponseStatus(HttpStatus.OK)
-    public List<SkillMapGetDTO> getAllSkillMaps(@RequestHeader("Authorization") String token) {
+    public List<SkillMapGetDTO> getAllSkillMaps(@RequestHeader("Authorization") String authHeader) {
+        String token = authHeader.substring("Bearer ".length()).trim();
         List<SkillMap> skillMaps = skillMapService.getSkillMaps(token);
         List<SkillMapGetDTO> skillMapGetDTOs = new ArrayList<>();
         for (SkillMap skillmap : skillMaps) {
@@ -44,7 +45,8 @@ public class SkillMapController {
     // 202 - POST /skillmaps
     @PostMapping
     @ResponseStatus(HttpStatus.CREATED)
-    public SkillMapGetDTO createSkillMap(@RequestBody SkillMapPostDTO skillMapPostDTO, @RequestHeader("Authorization") String token) {
+    public SkillMapGetDTO createSkillMap(@RequestBody SkillMapPostDTO skillMapPostDTO, @RequestHeader("Authorization") String authHeader) {
+        String token = authHeader.substring("Bearer ".length()).trim();
         SkillMap newSkillMap = DTOMapper.INSTANCE.convertSkillMapPostDTOtoEntity(skillMapPostDTO);
         SkillMap created = skillMapService.createSkillMap(newSkillMap, token);
         return DTOMapper.INSTANCE.convertEntityToSkillMapGetDTO(created);
@@ -53,7 +55,8 @@ public class SkillMapController {
     // 203 - GET /skillmaps/{skillMapId}
     @GetMapping("/{skillMapId}")
     @ResponseStatus(HttpStatus.OK)
-    public SkillMapGetDTO getSkillMapById(@PathVariable Long skillMapId, @RequestHeader("Authorization") String token) {
+    public SkillMapGetDTO getSkillMapById(@PathVariable Long skillMapId, @RequestHeader("Authorization") String authHeader) {
+        String token = authHeader.substring("Bearer ".length()).trim();
         SkillMap skillMap = skillMapService.getSkillMapById(skillMapId, token);
         return DTOMapper.INSTANCE.convertEntityToSkillMapGetDTO(skillMap);
     }
@@ -61,7 +64,8 @@ public class SkillMapController {
     // 204 - PATCH /skillmaps/{skillMapId} (spec 204 uses PATCH, not PUT)
     @PatchMapping("/{skillMapId}")
     @ResponseStatus(HttpStatus.OK)
-    public SkillMapGetDTO updateSkillMap(@PathVariable Long skillMapId, @RequestBody SkillMapPutDTO skillMapPutDTO, @RequestHeader("Authorization") String token) {
+    public SkillMapGetDTO updateSkillMap(@PathVariable Long skillMapId, @RequestBody SkillMapPutDTO skillMapPutDTO, @RequestHeader("Authorization") String authHeader) {
+        String token = authHeader.substring("Bearer ".length()).trim();
         SkillMap updates = DTOMapper.INSTANCE.convertSkillMapPutDTOtoEntity(skillMapPutDTO);
         SkillMap updated = skillMapService.updateSkillMap(skillMapId, updates, token);
         return DTOMapper.INSTANCE.convertEntityToSkillMapGetDTO(updated);
@@ -70,14 +74,16 @@ public class SkillMapController {
     // 205 - DELETE /skillmaps/{skillMapId}
     @DeleteMapping("/{skillMapId}")
     @ResponseStatus(HttpStatus.NO_CONTENT)
-    public void deleteSkillMap(@PathVariable Long skillMapId, @RequestHeader("Authorization") String token) {
+    public void deleteSkillMap(@PathVariable Long skillMapId, @RequestHeader("Authorization") String authHeader) {
+        String token = authHeader.substring("Bearer ".length()).trim();
         skillMapService.deleteSkillMap(skillMapId, token);
     }
 
     // 206 - POST /skillmaps/join
     @PostMapping("/join")
     @ResponseStatus(HttpStatus.CREATED)
-    public SkillMapMembershipGetDTO joinSkillMap(@RequestBody SkillMapJoinDTO joinDTO, @RequestHeader("Authorization") String token) {
+    public SkillMapMembershipGetDTO joinSkillMap(@RequestBody SkillMapJoinDTO joinDTO, @RequestHeader("Authorization") String authHeader) {
+        String token = authHeader.substring("Bearer ".length()).trim();
         SkillMapMembership membership = skillMapService.joinSkillMap(joinDTO.getSkillMapId(), joinDTO.getInviteCode(), token);
         return DTOMapper.INSTANCE.convertEntityToSkillMapMembershipGetDTO(membership);
     }
@@ -85,7 +91,8 @@ public class SkillMapController {
     // 207 - GET /skillmaps/{skillMapId}/members
     @GetMapping("/{skillMapId}/members")
     @ResponseStatus(HttpStatus.OK)
-    public List<UserGetDTO> getMembers(@PathVariable Long skillMapId, @RequestHeader("Authorization") String token) {
+    public List<UserGetDTO> getMembers(@PathVariable Long skillMapId, @RequestHeader("Authorization") String authHeader) {
+        String token = authHeader.substring("Bearer ".length()).trim();
         List<User> members = skillMapService.getMembers(skillMapId, token);
         List<UserGetDTO> memberDTOs = new ArrayList<>();
         for (User member : members) {
@@ -97,14 +104,16 @@ public class SkillMapController {
     // 208 - DELETE /skillmaps/{skillMapId}/members/{userId}
     @DeleteMapping("/{skillMapId}/members/{userId}")
     @ResponseStatus(HttpStatus.NO_CONTENT)
-    public void removeMember(@PathVariable Long skillMapId, @PathVariable Long userId, @RequestHeader("Authorization") String token) {
+    public void removeMember(@PathVariable Long skillMapId, @PathVariable Long userId, @RequestHeader("Authorization") String authHeader) {
+        String token = authHeader.substring("Bearer ".length()).trim();
         skillMapService.removeMember(skillMapId, userId, token);
     }
 
     // 209 - GET /skillmaps/{skillMapId}/graph
     @GetMapping("/{skillMapId}/graph")
     @ResponseStatus(HttpStatus.OK)
-    public SkillMapGraphDTO getSkillMapGraph(@PathVariable Long skillMapId, @RequestHeader("Authorization") String token) {
+    public SkillMapGraphDTO getSkillMapGraph(@PathVariable Long skillMapId, @RequestHeader("Authorization") String authHeader) {
+        String token = authHeader.substring("Bearer ".length()).trim();
         return skillMapService.getSkillMapGraph(skillMapId, token);
     }
 }

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/controller/UserController.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/controller/UserController.java
@@ -18,9 +18,8 @@ import jakarta.validation.Valid;
  * the user.
  * The controller will receive the request and delegate the execution to the
  * UserService and finally return the result.
- * 
- * Authorization works over RequestHeader. Required is set to false so we can control the error and 
- * throw 401 unauthorized with checkToken() instead of standard 400 bad request (for wrong header).
+ *
+ * Authorization is handled by AuthInterceptor for all protected endpoints.
  */
 @RestController
 public class UserController {
@@ -55,24 +54,27 @@ public class UserController {
 
 	@PostMapping("/auth/logout")
 	@ResponseStatus(HttpStatus.NO_CONTENT)
-	public void logout(@RequestHeader(value = "Authorization", required = false) String auth) {
-		User user = userService.checkToken(auth);
+	public void logout(@RequestHeader("Authorization") String authHeader) {
+		String token = authHeader.substring("Bearer ".length()).trim();
+		User user = userService.getUserByToken(token);
 		userService.logoutUser(user);
 	}
 
 	@GetMapping("/users/me")
 	@ResponseStatus(HttpStatus.OK)
-	public UserGetDTO getUser(@RequestHeader(value = "Authorization", required = false) String auth) {
-		User user = userService.checkToken(auth);
+	public UserGetDTO getUser(@RequestHeader("Authorization") String authHeader) {
+		String token = authHeader.substring("Bearer ".length()).trim();
+		User user = userService.getUserByToken(token);
 		return DTOMapper.INSTANCE.convertEntityToUserGetDTO(user);
 	}
-	
+
 	@PatchMapping("/users/me")
 	@ResponseStatus(HttpStatus.OK)
 	@ResponseBody
 	public UserGetDTO changeUserProfile(@RequestBody UserPatchDTO dto,
-			@RequestHeader(value = "Authorization", required = false) String auth) {
-		User requestingUser = userService.checkToken(auth);
+			@RequestHeader("Authorization") String authHeader) {
+		String token = authHeader.substring("Bearer ".length()).trim();
+		User requestingUser = userService.getUserByToken(token);
 		User userInput = DTOMapper.INSTANCE.convertUserPatchDTOtoEntity(dto);
 		User changedUser = userService.changeUserInformation(requestingUser, userInput);
 		return DTOMapper.INSTANCE.convertEntityToUserGetDTO(changedUser);
@@ -81,26 +83,26 @@ public class UserController {
 	@DeleteMapping("/users/me")
 	@ResponseStatus(HttpStatus.NO_CONTENT)
 	@ResponseBody
-	public void deleteUserProfile(@RequestHeader(value = "Authorization", required = false) String auth, @RequestBody String password) {
-		User user = userService.checkToken(auth);
+	public void deleteUserProfile(@RequestHeader("Authorization") String authHeader, @RequestBody String password) {
+		String token = authHeader.substring("Bearer ".length()).trim();
+		User user = userService.getUserByToken(token);
 		userService.deleteUserProfile(user, password);
 	}
 
 	@GetMapping("/users/{id}")
 	@ResponseStatus(HttpStatus.OK)
 	@ResponseBody
-	public UserGetDTO getUserById(@PathVariable("id") Long id,
-			@RequestHeader(value = "Authorization", required = false) String auth) {
-		userService.checkToken(auth);
-		User RequestedUser = userService.getUserById(id);
-		return DTOMapper.INSTANCE.convertEntityToUserGetDTO(RequestedUser);
+	public UserGetDTO getUserById(@PathVariable Long id) {
+		User requestedUser = userService.getUserById(id);
+		return DTOMapper.INSTANCE.convertEntityToUserGetDTO(requestedUser);
 	}
 
 	@PutMapping("/users/me/avatar")
 	@ResponseStatus(HttpStatus.OK)
 	@ResponseBody
-	public UserGetDTO changeUserAvatar(@RequestBody UserPutAvatarDTO dto, @RequestHeader(value = "Authorization", required = false) String auth) {
-		User requestingUser = userService.checkToken(auth);
+	public UserGetDTO changeUserAvatar(@RequestBody UserPutAvatarDTO dto, @RequestHeader("Authorization") String authHeader) {
+		String token = authHeader.substring("Bearer ".length()).trim();
+		User requestingUser = userService.getUserByToken(token);
 		User userInput = DTOMapper.INSTANCE.convertUserPutAvatarDTOtoEntity(dto);
 		User changedUser = userService.changeUserAvatar(requestingUser, userInput);
 		return DTOMapper.INSTANCE.convertEntityToUserGetDTO(changedUser);

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/controller/UserController.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/controller/UserController.java
@@ -12,9 +12,6 @@ import ch.uzh.ifi.hase.soprafs26.service.UserService;
 import ch.uzh.ifi.hase.soprafs26.rest.dto.UserPutAvatarDTO;
 import jakarta.validation.Valid;
 
-import java.util.ArrayList;
-import java.util.List;
-
 /**
  * User Controller
  * This class is responsible for handling all REST request that are related to
@@ -97,24 +94,6 @@ public class UserController {
 		userService.checkToken(auth);
 		User RequestedUser = userService.getUserById(id);
 		return DTOMapper.INSTANCE.convertEntityToUserGetDTO(RequestedUser);
-	}
-
-
-	@GetMapping("/users")
-	@ResponseStatus(HttpStatus.OK)
-	@ResponseBody
-	public List<UserGetDTO> getAllUsers(@RequestHeader(value = "Authorization", required = false) String auth) {
-		userService.checkToken(auth);
-
-		// fetch all users in the internal representation
-		List<User> users = userService.getUsers();
-		List<UserGetDTO> userGetDTOs = new ArrayList<>();
-
-		// convert each user to the API representation
-		for (User user : users) {
-			userGetDTOs.add(DTOMapper.INSTANCE.convertEntityToUserGetDTO(user));
-		}
-		return userGetDTOs;
 	}
 
 	@PutMapping("/users/me/avatar")

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/interceptor/AuthInterceptor.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/interceptor/AuthInterceptor.java
@@ -1,0 +1,42 @@
+package ch.uzh.ifi.hase.soprafs26.interceptor;
+
+import ch.uzh.ifi.hase.soprafs26.service.UserService;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Component;
+import org.springframework.web.server.ResponseStatusException;
+import org.springframework.web.servlet.HandlerInterceptor;
+
+@Component
+public class AuthInterceptor implements HandlerInterceptor {
+
+    private final UserService userService;
+
+    public AuthInterceptor(UserService userService) {
+        this.userService = userService;
+    }
+
+    @Override
+    public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) {
+        String authorizationHeader = request.getHeader("Authorization");
+
+        if (authorizationHeader == null || authorizationHeader.isBlank()) {
+            throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, "Missing Authorization header");
+        }
+
+        final String prefix = "Bearer ";
+        if (!authorizationHeader.startsWith(prefix)) {
+            throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, "Invalid Authorization header");
+        }
+
+        String token = authorizationHeader.substring(prefix.length()).trim();
+        if (token.isEmpty()) {
+            throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, "Missing token");
+        }
+
+        userService.getUserByToken(token); // throws 401 if token invalid or user not ONLINE
+
+        return true; // proceed to controller
+    }
+}

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/repository/UserRepository.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/repository/UserRepository.java
@@ -10,7 +10,7 @@ import ch.uzh.ifi.hase.soprafs26.entity.User;
 @Repository("userRepository")
 public interface UserRepository extends JpaRepository<User, Long> {
 
-	User findByUsername(String username);
+	Optional<User> findByUsername(String username);
 
 	Optional<User> findByToken(String token);
 }

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/service/SkillMapService.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/service/SkillMapService.java
@@ -42,7 +42,7 @@ public class SkillMapService {
 
     // 201 - returns only maps the requester is a member of (spec 201.1)
     public List<SkillMap> getSkillMaps(String token) {
-        User requester = userService.checkToken(token);
+        User requester = userService.getUserByToken(token);
         List<SkillMapMembership> memberships = skillMapMembershipRepository.findByUserId(requester.getId());
         List<Long> skillMapIds = memberships.stream()
                 .map(SkillMapMembership::getSkillMapId)
@@ -58,7 +58,7 @@ public class SkillMapService {
 
     // 202 - creates a skill map and auto-adds the creator as OWNER member
     public SkillMap createSkillMap(SkillMap newSkillMap, String token) {
-        User owner = userService.checkToken(token);
+        User owner = userService.getUserByToken(token);
         if (newSkillMap.getTitle() == null || newSkillMap.getTitle().isBlank()) {
             throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Title is required.");
         }
@@ -86,7 +86,7 @@ public class SkillMapService {
 
     // 203 - access control: public maps are open to all, private maps require membership
     public SkillMap getSkillMapById(Long skillMapId, String token) {
-        User requester = userService.checkToken(token);
+        User requester = userService.getUserByToken(token);
         Optional<SkillMap> requestedSkillMap = skillMapRepository.findById(skillMapId);
 
         if (!requestedSkillMap.isPresent()) {
@@ -106,7 +106,7 @@ public class SkillMapService {
 
     // 204 - only the owner can update; partial update (only non-null fields are applied)
     public SkillMap updateSkillMap(Long skillMapId, SkillMap updates, String token) {
-        User requester = userService.checkToken(token);
+        User requester = userService.getUserByToken(token);
         SkillMap existing = getSkillMapById(skillMapId, token);
         checkIsOwner(existing, requester);
 
@@ -133,7 +133,7 @@ public class SkillMapService {
 
     // 205 - only the owner can delete; memberships are cleaned up first
     public void deleteSkillMap(Long skillMapId, String token) {
-        User requester = userService.checkToken(token);
+        User requester = userService.getUserByToken(token);
         Optional<SkillMap> mapOpt = skillMapRepository.findById(skillMapId);
         if (!mapOpt.isPresent()) {
             throw new ResponseStatusException(HttpStatus.NOT_FOUND,
@@ -153,7 +153,7 @@ public class SkillMapService {
 
     // 206 - join a skillmap via invite code
     public SkillMapMembership joinSkillMap(Long skillMapId, String inviteCode, String token) {
-        User requester = userService.checkToken(token);
+        User requester = userService.getUserByToken(token);
 
         SkillMap map = skillMapRepository.findById(skillMapId)
                 .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND,
@@ -196,7 +196,7 @@ public class SkillMapService {
 
     // 208 - owner or the affected member themselves can remove a membership (spec 208.2)
     public void removeMember(Long skillMapId, Long userId, String token) {
-        User requester = userService.checkToken(token);
+        User requester = userService.getUserByToken(token);
         Optional<SkillMap> mapOpt = skillMapRepository.findById(skillMapId);
         if (!mapOpt.isPresent()) {
             throw new ResponseStatusException(HttpStatus.NOT_FOUND,

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/service/UserService.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/service/UserService.java
@@ -88,30 +88,6 @@ public class UserService {
 		user.setStatus(UserStatus.OFFLINE);
 	}
 
-	public User checkToken(String authorizationHeader) {
-		if (authorizationHeader == null || authorizationHeader.isBlank()) {
-			throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, "Missing Authorization header");
-		}
-
-		final String prefix = "Bearer "; // erwartet: "Bearer <token>"
-		if (!authorizationHeader.startsWith(prefix)) {
-			throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, "Invalid Authorization header");
-		}
-
-		String token = authorizationHeader.substring(prefix.length()).trim();
-		if (token.isEmpty()) {
-			throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, "Missing token");
-		}
-
-		User user = userRepository.findByToken(token)
-				.orElseThrow(() -> new ResponseStatusException(HttpStatus.UNAUTHORIZED, "Invalid token"));
-
-		if (user.getStatus() != UserStatus.ONLINE) {
-			throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, "User not online");
-		}
-
-		return user;
-	}
 
 
 
@@ -133,8 +109,14 @@ public class UserService {
 	}
 
 	public User getUserByToken(String token) {
-    return userRepository.findByToken(token)
-        .orElseThrow(() -> new ResponseStatusException(HttpStatus.UNAUTHORIZED, "Invalid token"));
+		User user = userRepository.findByToken(token)
+				.orElseThrow(() -> new ResponseStatusException(HttpStatus.UNAUTHORIZED, "Invalid token"));
+
+		if (user.getStatus() != UserStatus.ONLINE) {
+			throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, "User not online");
+		}
+
+		return user;
 	}
 
 	public User changeUserInformation(User requestingUser, User userInput) {

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/service/UserService.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/service/UserService.java
@@ -60,11 +60,9 @@ public class UserService {
 	}
 
 	private void checkIfUserExists(User userToBeCreated) {
-		User userByUsername = userRepository.findByUsername(userToBeCreated.getUsername());
-		if (userByUsername != null) {
-			throw new ResponseStatusException(HttpStatus.CONFLICT,
-					"The username provided is not unique. Therefore, the user could not be created!");
-		}
+		userRepository.findByUsername(userToBeCreated.getUsername())
+				.ifPresent(u -> { throw new ResponseStatusException(HttpStatus.CONFLICT,
+						"The username provided is not unique. Therefore, the user could not be created!"); });
 	}
 
 	private String hashPassword(String password) {
@@ -72,11 +70,8 @@ public class UserService {
 	}
 
 	public User loginUser(User userLoginData) {
-		User userDBEntry = userRepository.findByUsername(userLoginData.getUsername());
-
-		if (userDBEntry == null) {
-			throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Invalid or incomplete login request");
-		}
+		User userDBEntry = userRepository.findByUsername(userLoginData.getUsername())
+				.orElseThrow(() -> new ResponseStatusException(HttpStatus.BAD_REQUEST, "Invalid or incomplete login request"));
 
 		if (!passwordEncoder.matches(userLoginData.getPassword(), userDBEntry.getPassword())) {
 			throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, "Invalid password");
@@ -129,6 +124,11 @@ public class UserService {
 
 	public User getUserById(Long id) {
 		return userRepository.findById(id)
+				.orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "User not found"));
+	}
+
+	public User getUserByUsername(String username) {
+		return userRepository.findByUsername(username)
 				.orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "User not found"));
 	}
 

--- a/src/test/java/ch/uzh/ifi/hase/soprafs26/controller/SkillMapControllerTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs26/controller/SkillMapControllerTest.java
@@ -8,6 +8,7 @@ import ch.uzh.ifi.hase.soprafs26.entity.User;
 import ch.uzh.ifi.hase.soprafs26.rest.dto.SkillMapPostDTO;
 import ch.uzh.ifi.hase.soprafs26.rest.dto.SkillMapPutDTO;
 import ch.uzh.ifi.hase.soprafs26.service.SkillMapService;
+import ch.uzh.ifi.hase.soprafs26.service.UserService;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -36,6 +37,9 @@ public class SkillMapControllerTest {
 
     @MockitoBean
     private SkillMapService skillMapService;
+
+    @MockitoBean
+    private UserService userService;
 
     private static final String TOKEN = "Bearer test-token";
 

--- a/src/test/java/ch/uzh/ifi/hase/soprafs26/controller/SkillMapControllerTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs26/controller/SkillMapControllerTest.java
@@ -16,14 +16,11 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
-import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
 import org.springframework.web.server.ResponseStatusException;
 
 import java.util.ArrayList;
-import java.util.List;
 
 import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.hasSize;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;

--- a/src/test/java/ch/uzh/ifi/hase/soprafs26/controller/UserControllerTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs26/controller/UserControllerTest.java
@@ -23,7 +23,6 @@ import org.springframework.web.server.ResponseStatusException;
 import static org.hamcrest.Matchers.is;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.ArgumentMatchers.nullable;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.willThrow;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
@@ -84,13 +83,9 @@ public class UserControllerTest {
 	// mock User authentication
 	private void mockUserAuthentication(User user, boolean success) {
 		if (success) {
-			given(userService.checkToken(nullable(String.class)))
-					.willReturn(user);
-
-		} else {
-			given(userService.checkToken(nullable(String.class)))
-					.willThrow(new ResponseStatusException(HttpStatus.UNAUTHORIZED, "Missing Authorization header"));
+			given(userService.getUserByToken(any())).willReturn(user);
 		}
+		// failure case: no Authorization header → interceptor throws 401, no mocking needed
 	}
 
 	@Test
@@ -212,6 +207,7 @@ public class UserControllerTest {
 		mockUserAuthentication(logoutUser, true);
 
 		MockHttpServletRequestBuilder postRequest = post("/auth/logout")
+				.header("Authorization", "Bearer " + TOKEN)
 				.contentType(MediaType.APPLICATION_JSON);
 
 		mockMvc.perform(postRequest)
@@ -237,6 +233,7 @@ public class UserControllerTest {
 		mockUserAuthentication(user, true);
 
 		MockHttpServletRequestBuilder getRequest = get("/users/me")
+				.header("Authorization", "Bearer " + TOKEN)
 				.contentType(MediaType.APPLICATION_JSON);
 
 		mockMvc.perform(getRequest)
@@ -265,7 +262,7 @@ public class UserControllerTest {
 		updatedUser.setStatus(UserStatus.ONLINE);
 
 		// mocks
-		given(userService.checkToken(any())).willReturn(authUser);
+		mockUserAuthentication(authUser, true);
 		given(userService.changeUserInformation(any(User.class), any(User.class))).willReturn(updatedUser);
 
 		// request
@@ -302,6 +299,7 @@ public class UserControllerTest {
 						HttpStatus.CONFLICT, "Username already exists"));
 
 		MockHttpServletRequestBuilder patchRequest = patch("/users/me")
+				.header("Authorization", "Bearer " + TOKEN)
 				.contentType(MediaType.APPLICATION_JSON)
 				.content(asJsonString(new UserPatchDTO()));
 
@@ -314,6 +312,7 @@ public class UserControllerTest {
 		mockUserAuthentication(newUser(), true);
 
 		MockHttpServletRequestBuilder deleteRequest = delete("/users/me")
+				.header("Authorization", "Bearer " + TOKEN)
 				.contentType(MediaType.APPLICATION_JSON)
 				.content(PASSWORD);
 
@@ -329,6 +328,7 @@ public class UserControllerTest {
 				.given(userService).deleteUserProfile(any(User.class), eq(PASSWORD));
 
 		MockHttpServletRequestBuilder deleteRequest = delete("/users/me")
+				.header("Authorization", "Bearer " + TOKEN)
 				.contentType(MediaType.APPLICATION_JSON)
 				.content(PASSWORD);
 
@@ -427,6 +427,7 @@ public class UserControllerTest {
 		given(userService.changeUserAvatar(any(User.class), any(User.class))).willReturn(newUser());
 
 		MockHttpServletRequestBuilder putRequest = put("/users/me/avatar")
+				.header("Authorization", "Bearer " + TOKEN)
 				.contentType(MediaType.APPLICATION_JSON)
 				.content(asJsonString(new UserPutAvatarDTO()));
 

--- a/src/test/java/ch/uzh/ifi/hase/soprafs26/controller/UserControllerTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs26/controller/UserControllerTest.java
@@ -403,56 +403,6 @@ public class UserControllerTest {
 				.andExpect(status().isNotFound());
 	}
 
-	/*
-	 * The following tests are for getUsers (List), and Endpoint from M1 that we
-	 * dont have in specs. I'll leave them for now
-	 * Would also require the following static imports:
-	 * import java.util.Collections;
-	 * import java.util.List;
-	 * import static org.hamcrest.Matchers.hasSize;
-	 * 
-	 * @Test
-	 * public void givenAuthenticatedUser_whenGetUsers_thenReturnUserList() throws
-	 * Exception {
-	 * // Define desired server response
-	 * User user = newUser();
-	 * List<User> allUsers = Collections.singletonList(user);
-	 * 
-	 * // this mocks the UserService, meaning "it would return this if it were used"
-	 * given(userService.getUsers()).willReturn(allUsers);
-	 * mockUserAuthentication(user, true);
-	 * 
-	 * // Define HTTP request
-	 * MockHttpServletRequestBuilder getRequest = get("/users")
-	 * .header("Authorization", "Bearer test-token")
-	 * .contentType(MediaType.APPLICATION_JSON);
-	 * 
-	 * // then do requests
-	 * mockMvc.perform(getRequest)
-	 * .andExpect(status().isOk())
-	 * .andExpect(jsonPath("$", hasSize(1)))
-	 * .andExpect(jsonPath("$[0].username", is(user.getUsername())))
-	 * .andExpect(jsonPath("$[0].bio", is(user.getBio())))
-	 * .andExpect(jsonPath("$[0].token").doesNotExist())
-	 * .andExpect(jsonPath("$[0].status", is(user.getStatus().toString())));
-	 * }
-	 * 
-	 * @Test
-	 * public void givenNoAuthorization_whenGetUsers_thenReturnUnauthorized() throws
-	 * Exception {
-	 * // Mock
-	 * mockUserAuthentication(newUser(), false);
-	 * 
-	 * // Define HTTP request
-	 * MockHttpServletRequestBuilder getRequest = get("/users")
-	 * .contentType(MediaType.APPLICATION_JSON);
-	 * 
-	 * // then do requests
-	 * mockMvc.perform(getRequest)
-	 * .andExpect(status().isUnauthorized());
-	 * }
-	 */
-
 	/**
 	 * Helper Method to convert userPostDTO into a JSON string such that the input
 	 * can be processed

--- a/src/test/java/ch/uzh/ifi/hase/soprafs26/service/UserServiceIntegrationTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs26/service/UserServiceIntegrationTest.java
@@ -129,7 +129,7 @@ public class UserServiceIntegrationTest {
 
 		userService.deleteUserProfile(createdUser, RAW_PASSWORD);
 
-		assertNull(userRepository.findByUsername(TEST_USERNAME));
+		assertFalse(userRepository.findByUsername(TEST_USERNAME).isPresent());
 		assertFalse(userRepository.findById(id).isPresent());
 	}
 

--- a/src/test/java/ch/uzh/ifi/hase/soprafs26/service/UserServiceTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs26/service/UserServiceTest.java
@@ -88,7 +88,7 @@ public class UserServiceTest {
 	public void createUser_duplicateUsername_throwsException() {
 		User input = buildNewUser();
 
-		Mockito.when(userRepository.findByUsername(TEST_USERNAME)).thenReturn(buildPersistedUser());
+		Mockito.when(userRepository.findByUsername(TEST_USERNAME)).thenReturn(Optional.of(buildPersistedUser()));
 
 		assertThrows(ResponseStatusException.class, () -> userService.createUser(input));
 	}
@@ -98,7 +98,7 @@ public class UserServiceTest {
 
 	@Test
 	public void loginUser_validCredentials_success() {
-		Mockito.when(userRepository.findByUsername(TEST_USERNAME)).thenReturn(buildPersistedUser());
+		Mockito.when(userRepository.findByUsername(TEST_USERNAME)).thenReturn(Optional.of(buildPersistedUser()));
 
 		User result = userService.loginUser(buildNewUser());
 
@@ -108,14 +108,14 @@ public class UserServiceTest {
 
 	@Test
 	public void loginUser_userNotFound_throwsException() {
-		Mockito.when(userRepository.findByUsername(Mockito.any())).thenReturn(null);
+		Mockito.when(userRepository.findByUsername(Mockito.any())).thenReturn(Optional.empty());
 
 		assertThrows(ResponseStatusException.class, () -> userService.loginUser(buildNewUser()));
 	}
 
 	@Test
 	public void loginUser_wrongPassword_throwsException() {
-		Mockito.when(userRepository.findByUsername(TEST_USERNAME)).thenReturn(buildPersistedUser());
+		Mockito.when(userRepository.findByUsername(TEST_USERNAME)).thenReturn(Optional.of(buildPersistedUser()));
 
 		User loginInput = new User();
 		loginInput.setPassword("wrongPassword");
@@ -204,7 +204,7 @@ public class UserServiceTest {
 		User input = new User();
 		input.setUsername("newUsername");
 
-		Mockito.when(userRepository.findByUsername("newUsername")).thenReturn(null);
+		Mockito.when(userRepository.findByUsername("newUsername")).thenReturn(Optional.empty());
 
 		User result = userService.changeUserInformation(requestingUser, input);
 
@@ -218,7 +218,7 @@ public class UserServiceTest {
 		User input = new User();
 		input.setUsername("takenUsername");
 
-		Mockito.when(userRepository.findByUsername("takenUsername")).thenReturn(buildPersistedUser());
+		Mockito.when(userRepository.findByUsername("takenUsername")).thenReturn(Optional.of(buildPersistedUser()));
 
 		assertThrows(ResponseStatusException.class, () -> userService.changeUserInformation(requestingUser, input));
 	}

--- a/src/test/java/ch/uzh/ifi/hase/soprafs26/service/UserServiceTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs26/service/UserServiceTest.java
@@ -137,41 +137,31 @@ public class UserServiceTest {
 	}
 
 
-	// --- checkToken ---
+	// --- getUserByToken ---
 
 	@Test
-	public void checkToken_validToken_returnsUser() {
+	public void getUserByToken_validToken_returnsUser() {
 		Mockito.when(userRepository.findByToken(TEST_TOKEN)).thenReturn(Optional.of(buildPersistedUser()));
 
-		User result = userService.checkToken("Bearer " + TEST_TOKEN);
+		User result = userService.getUserByToken(TEST_TOKEN);
 
 		assertEquals(TEST_ID, result.getId());
 	}
 
 	@Test
-	public void checkToken_nullHeader_throwsException() {
-		assertThrows(ResponseStatusException.class, () -> userService.checkToken(null));
-	}
-
-	@Test
-	public void checkToken_missingBearerPrefix_throwsException() {
-		assertThrows(ResponseStatusException.class, () -> userService.checkToken(TEST_TOKEN));
-	}
-
-	@Test
-	public void checkToken_tokenNotFound_throwsException() {
+	public void getUserByToken_tokenNotFound_throwsException() {
 		Mockito.when(userRepository.findByToken(Mockito.any())).thenReturn(Optional.empty());
 
-		assertThrows(ResponseStatusException.class, () -> userService.checkToken("Bearer invalid-token"));
+		assertThrows(ResponseStatusException.class, () -> userService.getUserByToken("invalid-token"));
 	}
 
 	@Test
-	public void checkToken_userOffline_throwsException() {
+	public void getUserByToken_userOffline_throwsException() {
 		User offlineUser = buildPersistedUser();
 		offlineUser.setStatus(UserStatus.OFFLINE);
 		Mockito.when(userRepository.findByToken(TEST_TOKEN)).thenReturn(Optional.of(offlineUser));
 
-		assertThrows(ResponseStatusException.class, () -> userService.checkToken("Bearer " + TEST_TOKEN));
+		assertThrows(ResponseStatusException.class, () -> userService.getUserByToken(TEST_TOKEN));
 	}
 
 


### PR DESCRIPTION
Added all suggested refactors to S1
- deleted GET /users
- added interceptor
- added OpenAPI swagger
- several small refactors, like changing getUserByUsername from type User to type Optional<User> (standard, to my knowledge it was not like this in template because it's rather new)

Remark: GET users/{username} was not added since you cant have two GET users/{param} endpoints (the handler cant decide which one he wants to call). GET users/{id} seems more in line with the examples we have seen in SoEn and also was recommended by claude.