### PR TITLE
S5: minor fix to include dependencies in skillmap dependency response

### DIFF
--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/controller/DependencyController.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/controller/DependencyController.java
@@ -23,7 +23,8 @@ public class DependencyController {
     @ResponseStatus(HttpStatus.OK)
     public List<DependencyGetDTO> getDependenciesByMap(
             @PathVariable Long skillMapId,
-            @RequestHeader("Authorization") String token) {
+            @RequestHeader("Authorization") String authHeader) {
+        String token = authHeader.substring("Bearer ".length()).trim();
         return dependencyService.getDependenciesByMap(skillMapId, token)
             .stream()
             .map(DTOMapper.INSTANCE::convertDependencyEntityToGetDTO)
@@ -36,7 +37,8 @@ public class DependencyController {
     public DependencyGetDTO createDependency(
             @PathVariable Long skillMapId,
             @RequestBody DependencyPostDTO dependencyPostDTO,
-            @RequestHeader("Authorization") String token) {
+            @RequestHeader("Authorization") String authHeader) {
+        String token = authHeader.substring("Bearer ".length()).trim();
         Dependency created = dependencyService.createDependency(skillMapId, dependencyPostDTO.getFromSkillId(), dependencyPostDTO.getToSkillId(), token);
         return DTOMapper.INSTANCE.convertDependencyEntityToGetDTO(created);
     }
@@ -46,7 +48,8 @@ public class DependencyController {
     @ResponseStatus(HttpStatus.NO_CONTENT)
     public void deleteDependency(
             @PathVariable Long dependencyId,
-            @RequestHeader("Authorization") String token) {
+            @RequestHeader("Authorization") String authHeader) {
+        String token = authHeader.substring("Bearer ".length()).trim();
         dependencyService.deleteDependency(dependencyId, token);
     }
 }

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/rest/dto/SkillMapGraphDTO.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/rest/dto/SkillMapGraphDTO.java
@@ -6,8 +6,7 @@ public class SkillMapGraphDTO {
     private Long skillMapId;
     private String title;
     private List<SkillGetDTO> skills = List.of();
-    // TODO: replace with List<DependencyDTO> once Dependency entity is implemented
-    private List<?> dependencies = List.of();
+    private List<DependencyGetDTO> dependencies = List.of();
     // TODO: replace with List<StudentProgressDTO> once StudentProgress entity is implemented
     private List<?> progress = List.of();
 
@@ -17,6 +16,7 @@ public class SkillMapGraphDTO {
     public void setTitle(String title) { this.title = title; }
     public List<SkillGetDTO> getSkills() { return skills; }
     public void setSkills(List<SkillGetDTO> skills) { this.skills = skills; }
-    public List<?> getDependencies() { return dependencies; }
+    public List<DependencyGetDTO> getDependencies() { return dependencies; }
+    public void setDependencies(List<DependencyGetDTO> dependencies) { this.dependencies = dependencies; }
     public List<?> getProgress() { return progress; }
 }

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/service/SkillMapService.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/service/SkillMapService.java
@@ -18,9 +18,11 @@ import ch.uzh.ifi.hase.soprafs26.constant.SkillMapRole;
 import ch.uzh.ifi.hase.soprafs26.entity.SkillMap;
 import ch.uzh.ifi.hase.soprafs26.entity.SkillMapMembership;
 import ch.uzh.ifi.hase.soprafs26.entity.User;
+import ch.uzh.ifi.hase.soprafs26.repository.DependencyRepository;
 import ch.uzh.ifi.hase.soprafs26.repository.SkillMapMembershipRepository;
 import ch.uzh.ifi.hase.soprafs26.repository.SkillMapRepository;
 import ch.uzh.ifi.hase.soprafs26.repository.SkillRepository;
+import ch.uzh.ifi.hase.soprafs26.rest.dto.DependencyGetDTO;
 import ch.uzh.ifi.hase.soprafs26.rest.dto.SkillGetDTO;
 import ch.uzh.ifi.hase.soprafs26.rest.dto.SkillMapGraphDTO;
 import ch.uzh.ifi.hase.soprafs26.rest.mapper.DTOMapper;
@@ -34,16 +36,19 @@ public class SkillMapService {
     private final SkillMapMembershipRepository skillMapMembershipRepository;
     private final UserService userService;
     private final SkillRepository skillRepository;
+    private final DependencyRepository dependencyRepository;
 
     public SkillMapService(
             @Qualifier("skillMapRepository") SkillMapRepository skillMapRepository,
             @Qualifier("skillRepository") SkillRepository skillRepository,
             @Qualifier("skillMapMembershipRepository") SkillMapMembershipRepository skillMapMembershipRepository,
+            @Qualifier("dependencyRepository") DependencyRepository dependencyRepository,
             UserService userService) {
         this.skillMapRepository = skillMapRepository;
         this.skillMapMembershipRepository = skillMapMembershipRepository;
         this.userService = userService;
         this.skillRepository = skillRepository;
+        this.dependencyRepository = dependencyRepository;
     }
 
     // 201 - returns only maps the requester is a member of (spec 201.1)
@@ -235,17 +240,20 @@ public class SkillMapService {
                 .stream()
                 .map(DTOMapper.INSTANCE::convertEntityToSkillGetDTO)
                 .collect(Collectors.toList());
-        
-        //TODO: add dependencies as soon as this entity exists
 
+        List<Long> skillIds = skillDTOs.stream().map(SkillGetDTO::getId).collect(Collectors.toList());
+        List<DependencyGetDTO> dependencyDTOs = dependencyRepository.findByFromSkill_IdIn(skillIds)
+                .stream()
+                .map(DTOMapper.INSTANCE::convertDependencyEntityToGetDTO)
+                .collect(Collectors.toList());
 
         //TODO: add progress as soon as this entity exists
-
 
         SkillMapGraphDTO graph = new SkillMapGraphDTO();
         graph.setSkillMapId(map.getId());
         graph.setTitle(map.getTitle());
         graph.setSkills(skillDTOs);
+        graph.setDependencies(dependencyDTOs);
         return graph;
     }
 


### PR DESCRIPTION
minor fixes for front-end functionality S5
- stripped Authorisation: Bearer prefix in DependencyController
- implemented the dependency in GET /skillmaps/{id}/graph (was a forgotten TODO prior), caused errors in front-end by returning an empty list instead of the dependencies created