### PR TITLE
Collaboration session

### DIFF
--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/constant/SpeedFeedback.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/constant/SpeedFeedback.java
@@ -1,0 +1,5 @@
+package ch.uzh.ifi.hase.soprafs26.constant;
+
+public enum SpeedFeedback {
+    TOO_FAST, TOO_SLOW, OK
+}

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/controller/LiveQuestionController.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/controller/LiveQuestionController.java
@@ -4,7 +4,6 @@ import ch.uzh.ifi.hase.soprafs26.entity.LiveQuestion;
 import ch.uzh.ifi.hase.soprafs26.entity.User;
 import ch.uzh.ifi.hase.soprafs26.service.LiveQuestionService;
 import jakarta.servlet.http.HttpServletRequest;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
 
@@ -16,7 +15,6 @@ public class LiveQuestionController {
 
     private final LiveQuestionService liveQuestionService;
 
-    @Autowired
     public LiveQuestionController(LiveQuestionService liveQuestionService) {
         this.liveQuestionService = liveQuestionService;
     }

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/controller/SpeedFeedbackController.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/controller/SpeedFeedbackController.java
@@ -1,0 +1,28 @@
+package ch.uzh.ifi.hase.soprafs26.controller;
+
+import ch.uzh.ifi.hase.soprafs26.entity.User;
+import ch.uzh.ifi.hase.soprafs26.rest.dto.SpeedFeedbackPutDTO;
+import ch.uzh.ifi.hase.soprafs26.service.SpeedFeedbackService;
+import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/sessions/{sessionId}")
+public class SpeedFeedbackController {
+
+    private final SpeedFeedbackService speedFeedbackService;
+
+    public SpeedFeedbackController(SpeedFeedbackService speedFeedbackService) {
+        this.speedFeedbackService = speedFeedbackService;
+    }
+
+    @PutMapping("/speed")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    public void submitSpeedFeedback(@PathVariable Long sessionId,
+                                    @RequestBody SpeedFeedbackPutDTO body,
+                                    HttpServletRequest request) {
+        User user = (User) request.getAttribute("authenticatedUser");
+        speedFeedbackService.submitFeedback(sessionId, user.getId(), body.getFeedback());
+    }
+}

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/rest/dto/SkillMapGraphDTO.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/rest/dto/SkillMapGraphDTO.java
@@ -7,7 +7,6 @@ public class SkillMapGraphDTO {
     private String title;
     private List<SkillGetDTO> skills = List.of();
     private List<DependencyGetDTO> dependencies = List.of();
-    // TODO: replace with List<StudentProgressDTO> once StudentProgress entity is implemented
     private List<?> progress = List.of();
 
     public Long getSkillMapId() { return skillMapId; }

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/rest/dto/SpeedFeedbackPutDTO.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/rest/dto/SpeedFeedbackPutDTO.java
@@ -1,0 +1,11 @@
+package ch.uzh.ifi.hase.soprafs26.rest.dto;
+
+import ch.uzh.ifi.hase.soprafs26.constant.SpeedFeedback;
+
+public class SpeedFeedbackPutDTO {
+    private SpeedFeedback feedback;
+
+    public SpeedFeedback getFeedback() { return feedback; }
+    public void setFeedback(SpeedFeedback feedback) { this.feedback = feedback; }
+}
+

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/service/CollaborationSessionService.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/service/CollaborationSessionService.java
@@ -22,15 +22,18 @@ public class CollaborationSessionService {
     private final WebSocketBroadcastService broadcastService;
     private final LiveQuestionService liveQuestionService;
     private final SkillMapMembershipRepository membershipRepository;
+    private final SpeedFeedbackService speedFeedbackService;
 
     public CollaborationSessionService(CollaborationSessionRepository sessionRepository,
             WebSocketBroadcastService broadcastService, SkillMapRepository skillMapRepository,
-            SkillMapMembershipRepository membershipRepository, LiveQuestionService liveQuestionService) {
+            SkillMapMembershipRepository membershipRepository, LiveQuestionService liveQuestionService,
+            SpeedFeedbackService speedFeedbackService) {
         this.sessionRepository = sessionRepository;
         this.broadcastService = broadcastService;
         this.skillMapRepository = skillMapRepository;
         this.membershipRepository = membershipRepository;
         this.liveQuestionService = liveQuestionService;
+        this.speedFeedbackService = speedFeedbackService;
     }
 
     public CollaborationSession startSession(Long skillMapId, User user) {
@@ -69,6 +72,7 @@ public class CollaborationSessionService {
         session.setActive(false);
         session.setEndedAt(LocalDateTime.now());
         session = sessionRepository.save(session);
+        speedFeedbackService.clearSession(session.getId());
 
         //design decision to NOT delete the questions after session end
         // liveQuestionService.deleteAllQuestionsForSession(session.getId()); 
@@ -82,5 +86,10 @@ public class CollaborationSessionService {
         }
         return sessionRepository.findBySkillMapIdAndIsActiveTrue(skillMapId)
                 .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "No active session found"));
+    }
+
+    public CollaborationSession getSessionById(Long sessionId) {
+        return sessionRepository.findById(sessionId)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Session not found"));
     }
 }

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/service/CollaborationSessionService.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/service/CollaborationSessionService.java
@@ -20,19 +20,17 @@ public class CollaborationSessionService {
     private final SkillMapRepository skillMapRepository;
     private final CollaborationSessionRepository sessionRepository;
     private final WebSocketBroadcastService broadcastService;
-    private final LiveQuestionService liveQuestionService;
     private final SkillMapMembershipRepository membershipRepository;
     private final SpeedFeedbackService speedFeedbackService;
 
     public CollaborationSessionService(CollaborationSessionRepository sessionRepository,
             WebSocketBroadcastService broadcastService, SkillMapRepository skillMapRepository,
-            SkillMapMembershipRepository membershipRepository, LiveQuestionService liveQuestionService,
+            SkillMapMembershipRepository membershipRepository,
             SpeedFeedbackService speedFeedbackService) {
         this.sessionRepository = sessionRepository;
         this.broadcastService = broadcastService;
         this.skillMapRepository = skillMapRepository;
         this.membershipRepository = membershipRepository;
-        this.liveQuestionService = liveQuestionService;
         this.speedFeedbackService = speedFeedbackService;
     }
 

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/service/LiveQuestionService.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/service/LiveQuestionService.java
@@ -10,7 +10,6 @@ import ch.uzh.ifi.hase.soprafs26.repository.SkillMapRepository;
 import ch.uzh.ifi.hase.soprafs26.repository.UpvoteRecordRepository;
 import ch.uzh.ifi.hase.soprafs26.websocket.WebSocketBroadcastService;
 
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -28,7 +27,6 @@ public class LiveQuestionService {
     private final SkillMapRepository skillMapRepository;
     private final WebSocketBroadcastService webSocketBroadcastService;
 
-    @Autowired
     public LiveQuestionService(LiveQuestionRepository liveQuestionRepository,
                             UpvoteRecordRepository upvoteRecordRepository,
                             CollaborationSessionRepository collaborationSessionRepository,
@@ -93,7 +91,7 @@ public class LiveQuestionService {
 
         upvoteRecordRepository.delete(record);
         question.setUpvoteCount(Math.max(0, question.getUpvoteCount() - 1));
-        LiveQuestion saved = liveQuestionRepository.save(question);
+        liveQuestionRepository.save(question);
         webSocketBroadcastService.broadcastQuestionsState(question.getSessionId(), getQuestionsBySession(question.getSessionId()));
     }
 

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/service/SkillMapService.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/service/SkillMapService.java
@@ -230,8 +230,6 @@ public class SkillMapService {
                 .map(DTOMapper.INSTANCE::convertDependencyEntityToGetDTO)
                 .collect(Collectors.toList());
 
-        //TODO: add progress as soon as this entity exists
-
         SkillMapGraphDTO graph = new SkillMapGraphDTO();
         graph.setSkillMapId(map.getId());
         graph.setTitle(map.getTitle());

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/service/SpeedFeedbackService.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/service/SpeedFeedbackService.java
@@ -1,0 +1,59 @@
+package ch.uzh.ifi.hase.soprafs26.service;
+
+import ch.uzh.ifi.hase.soprafs26.constant.SpeedFeedback;
+import ch.uzh.ifi.hase.soprafs26.entity.CollaborationSession;
+import ch.uzh.ifi.hase.soprafs26.repository.CollaborationSessionRepository;
+import ch.uzh.ifi.hase.soprafs26.websocket.dto.SpeedUpdatedMessageDTO;
+import ch.uzh.ifi.hase.soprafs26.websocket.WebSocketBroadcastService;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+@Service
+public class SpeedFeedbackService {
+
+    private final ConcurrentHashMap<Long, ConcurrentHashMap<Long, SpeedFeedback>> speedVotes = new ConcurrentHashMap<>();
+
+    private final WebSocketBroadcastService webSocketBroadcastService;
+    private final CollaborationSessionRepository collaborationSessionRepository;
+
+    public SpeedFeedbackService(CollaborationSessionRepository collaborationSessionRepository,
+            WebSocketBroadcastService webSocketBroadcastService) {
+        this.collaborationSessionRepository = collaborationSessionRepository;
+        this.webSocketBroadcastService = webSocketBroadcastService;
+    }
+
+    public void submitFeedback(Long sessionId, Long userId, SpeedFeedback feedback) {
+        CollaborationSession session = collaborationSessionRepository.findById(sessionId)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Session not found"));
+        if (!session.isActive()) {
+            throw new ResponseStatusException(HttpStatus.FORBIDDEN, "Session is not active");
+        }
+        speedVotes
+                .computeIfAbsent(sessionId, id -> new ConcurrentHashMap<>())
+                .put(userId, feedback);
+        broadcastSpeedUpdate(sessionId);
+    }
+
+    public void clearSession(Long sessionId) {
+        speedVotes.remove(sessionId);
+    }
+
+    private void broadcastSpeedUpdate(Long sessionId) {
+        Long skillMapId = collaborationSessionRepository.findById(sessionId)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Session not found"))
+                .getSkillMapId();
+
+        Map<Long, SpeedFeedback> votes = speedVotes.getOrDefault(sessionId, new ConcurrentHashMap<>());
+
+        int tooFast = (int) votes.values().stream().filter(v -> v == SpeedFeedback.TOO_FAST).count();
+        int tooSlow = (int) votes.values().stream().filter(v -> v == SpeedFeedback.TOO_SLOW).count();
+        int totalResponses = votes.size();
+
+        webSocketBroadcastService.broadcastSpeedUpdated(skillMapId, tooFast, tooSlow, totalResponses);
+    }
+}

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/service/SpeedFeedbackService.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/service/SpeedFeedbackService.java
@@ -3,7 +3,6 @@ package ch.uzh.ifi.hase.soprafs26.service;
 import ch.uzh.ifi.hase.soprafs26.constant.SpeedFeedback;
 import ch.uzh.ifi.hase.soprafs26.entity.CollaborationSession;
 import ch.uzh.ifi.hase.soprafs26.repository.CollaborationSessionRepository;
-import ch.uzh.ifi.hase.soprafs26.websocket.dto.SpeedUpdatedMessageDTO;
 import ch.uzh.ifi.hase.soprafs26.websocket.WebSocketBroadcastService;
 
 import org.springframework.http.HttpStatus;

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/websocket/WebSocketBroadcastService.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/websocket/WebSocketBroadcastService.java
@@ -9,9 +9,9 @@ import org.springframework.stereotype.Service;
 import ch.uzh.ifi.hase.soprafs26.websocket.dto.RatingUpdatedMessageDTO;
 import ch.uzh.ifi.hase.soprafs26.websocket.dto.SessionEndedMessageDTO;
 import ch.uzh.ifi.hase.soprafs26.websocket.dto.SessionStartedMessageDTO;
+import ch.uzh.ifi.hase.soprafs26.websocket.dto.SpeedUpdatedMessageDTO;
 import ch.uzh.ifi.hase.soprafs26.entity.LiveQuestion;
 import ch.uzh.ifi.hase.soprafs26.websocket.dto.QuestionsStateMessageDTO;
-
 
 @Service
 public class WebSocketBroadcastService {
@@ -40,5 +40,10 @@ public class WebSocketBroadcastService {
     public void broadcastQuestionsState(long sessionId, List<LiveQuestion> questions) {
         String topic = String.format("/topic/sessions/%d/questions", sessionId);
         messagingTemplate.convertAndSend(topic, new QuestionsStateMessageDTO(sessionId, questions));
+    }
+
+    public void broadcastSpeedUpdated(long skillMapId, int tooFast, int tooSlow, int totalResponses) {
+        String topic = String.format("/topic/skillmaps/%d/live", skillMapId);
+        messagingTemplate.convertAndSend(topic, new SpeedUpdatedMessageDTO(tooFast, tooSlow, totalResponses));
     }
 }

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/websocket/dto/SpeedUpdatedMessageDTO.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/websocket/dto/SpeedUpdatedMessageDTO.java
@@ -1,0 +1,19 @@
+package ch.uzh.ifi.hase.soprafs26.websocket.dto;
+
+public class SpeedUpdatedMessageDTO {
+    private final String type = "SPEED_UPDATED";
+    private final int tooFast;
+    private final int tooSlow;
+    private final int totalResponses;
+
+    public SpeedUpdatedMessageDTO(int tooFast, int tooSlow, int totalResponses) {
+        this.tooFast = tooFast;
+        this.tooSlow = tooSlow;
+        this.totalResponses = totalResponses;
+    }
+
+    public String getType()         { return type; }
+    public int getTooFast()         { return tooFast; }
+    public int getTooSlow()         { return tooSlow; }
+    public int getTotalResponses()  { return totalResponses; }
+}

--- a/src/test/java/ch/uzh/ifi/hase/soprafs26/controller/SpeedFeedbackControllerTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs26/controller/SpeedFeedbackControllerTest.java
@@ -1,0 +1,118 @@
+package ch.uzh.ifi.hase.soprafs26.controller;
+
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.core.JacksonException;
+
+import ch.uzh.ifi.hase.soprafs26.constant.SpeedFeedback;
+import ch.uzh.ifi.hase.soprafs26.entity.User;
+import ch.uzh.ifi.hase.soprafs26.rest.dto.SpeedFeedbackPutDTO;
+import ch.uzh.ifi.hase.soprafs26.service.SpeedFeedbackService;
+import ch.uzh.ifi.hase.soprafs26.service.UserService;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.web.server.ResponseStatusException;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.willThrow;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(SpeedFeedbackController.class)
+public class SpeedFeedbackControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private SpeedFeedbackService speedFeedbackService;
+
+    @MockitoBean
+    private UserService userService;
+
+    private static final Long SESSION_ID = 10L;
+    private static final String TOKEN = "Bearer test-token";
+
+    private User buildUser() {
+        User user = new User();
+        user.setId(100L);
+        return user;
+    }
+
+    private void mockAuthentication(User user, boolean success) {
+        if (success) {
+            given(userService.getUserByToken(any())).willReturn(user);
+        }
+    }
+
+    private SpeedFeedbackPutDTO buildRequestBody(SpeedFeedback feedback) {
+        SpeedFeedbackPutDTO dto = new SpeedFeedbackPutDTO();
+        dto.setFeedback(feedback);
+        return dto;
+    }
+
+    // --- PUT /sessions/{sessionId}/speed ---
+
+    @Test
+    public void givenValidFeedback_whenSubmitSpeed_thenReturnNoContent() throws Exception {
+        mockAuthentication(buildUser(), true);
+
+        mockMvc.perform(put("/sessions/{sessionId}/speed", SESSION_ID)
+                .header("Authorization", TOKEN)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(asJsonString(buildRequestBody(SpeedFeedback.TOO_FAST))))
+                .andExpect(status().isNoContent());
+    }
+
+    @Test
+    public void givenSessionNotActive_whenSubmitSpeed_thenReturnForbidden() throws Exception {
+        mockAuthentication(buildUser(), true);
+        willThrow(new ResponseStatusException(HttpStatus.FORBIDDEN, "Session is not active"))
+                .given(speedFeedbackService).submitFeedback(eq(SESSION_ID), any(), any());
+
+        mockMvc.perform(put("/sessions/{sessionId}/speed", SESSION_ID)
+                .header("Authorization", TOKEN)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(asJsonString(buildRequestBody(SpeedFeedback.TOO_FAST))))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    public void givenSessionNotFound_whenSubmitSpeed_thenReturnNotFound() throws Exception {
+        mockAuthentication(buildUser(), true);
+        willThrow(new ResponseStatusException(HttpStatus.NOT_FOUND, "Session not found"))
+                .given(speedFeedbackService).submitFeedback(eq(SESSION_ID), any(), any());
+
+        mockMvc.perform(put("/sessions/{sessionId}/speed", SESSION_ID)
+                .header("Authorization", TOKEN)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(asJsonString(buildRequestBody(SpeedFeedback.TOO_SLOW))))
+                .andExpect(status().isNotFound());
+    }
+
+    @Test
+    public void givenNoAuthorization_whenSubmitSpeed_thenReturnUnauthorized() throws Exception {
+        mockAuthentication(buildUser(), false);
+
+        mockMvc.perform(put("/sessions/{sessionId}/speed", SESSION_ID)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(asJsonString(buildRequestBody(SpeedFeedback.OK))))
+                .andExpect(status().isUnauthorized());
+    }
+
+    private String asJsonString(final Object object) {
+        try {
+            return new ObjectMapper().writeValueAsString(object);
+        } catch (JacksonException e) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST,
+                    String.format("The request body could not be created.%s", e.toString()));
+        }
+    }
+}

--- a/src/test/java/ch/uzh/ifi/hase/soprafs26/service/CollaborationSessionServiceTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs26/service/CollaborationSessionServiceTest.java
@@ -166,8 +166,6 @@ public class CollaborationSessionServiceTest {
 
     // --- getActiveSession ---
 
-    // --- getActiveSession ---
-
     @Test
     public void getActiveSession_memberAndSessionExists_returnsSession() {
         Mockito.when(membershipRepository.existsBySkillMapIdAndUserId(SKILL_MAP_ID, OWNER_ID)).thenReturn(true);

--- a/src/test/java/ch/uzh/ifi/hase/soprafs26/service/CollaborationSessionServiceTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs26/service/CollaborationSessionServiceTest.java
@@ -39,6 +39,9 @@ public class CollaborationSessionServiceTest {
     private WebSocketBroadcastService broadcastService;
 
     @Mock
+    private SpeedFeedbackService speedFeedbackService;
+
+    @Mock
     private SkillMapMembershipRepository membershipRepository;
 
     @InjectMocks
@@ -130,6 +133,7 @@ public class CollaborationSessionServiceTest {
         Mockito.when(sessionRepository.findBySkillMapIdAndIsActiveTrue(SKILL_MAP_ID))
                 .thenReturn(Optional.of(buildActiveSession()));
         Mockito.when(sessionRepository.save(Mockito.any())).thenReturn(buildActiveSession());
+        Mockito.doNothing().when(speedFeedbackService).clearSession(Mockito.any());
 
         sessionService.endSession(SKILL_MAP_ID, buildOwner());
 

--- a/src/test/java/ch/uzh/ifi/hase/soprafs26/service/SpeedFeedbackServiceTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs26/service/SpeedFeedbackServiceTest.java
@@ -1,0 +1,138 @@
+package ch.uzh.ifi.hase.soprafs26.service;
+
+import ch.uzh.ifi.hase.soprafs26.constant.SpeedFeedback;
+import ch.uzh.ifi.hase.soprafs26.entity.CollaborationSession;
+import ch.uzh.ifi.hase.soprafs26.repository.CollaborationSessionRepository;
+import ch.uzh.ifi.hase.soprafs26.websocket.WebSocketBroadcastService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class SpeedFeedbackServiceTest {
+
+    private static final Long SESSION_ID = 10L;
+    private static final Long SKILL_MAP_ID = 1L;
+    private static final Long USER_ID = 100L;
+    private static final Long OTHER_USER_ID = 200L;
+
+    @Mock
+    private CollaborationSessionRepository collaborationSessionRepository;
+
+    @Mock
+    private WebSocketBroadcastService webSocketBroadcastService;
+
+    @InjectMocks
+    private SpeedFeedbackService speedFeedbackService;
+
+    @BeforeEach
+    public void setup() {
+        MockitoAnnotations.openMocks(this);
+    }
+
+    private CollaborationSession buildActiveSession() {
+        CollaborationSession session = new CollaborationSession();
+        ReflectionTestUtils.setField(session, "id", SESSION_ID);
+        session.setSkillMapId(SKILL_MAP_ID);
+        session.setActive(true);
+        return session;
+    }
+
+    private CollaborationSession buildInactiveSession() {
+        CollaborationSession session = new CollaborationSession();
+        ReflectionTestUtils.setField(session, "id", SESSION_ID);
+        session.setSkillMapId(SKILL_MAP_ID);
+        session.setActive(false);
+        return session;
+    }
+
+    // --- submitFeedback ---
+
+    @Test
+    public void submitFeedback_newVote_broadcastsCorrectCounts() {
+        Mockito.when(collaborationSessionRepository.findById(SESSION_ID))
+                .thenReturn(Optional.of(buildActiveSession()));
+
+        speedFeedbackService.submitFeedback(SESSION_ID, USER_ID, SpeedFeedback.TOO_FAST);
+
+        Mockito.verify(webSocketBroadcastService, Mockito.times(1))
+                .broadcastSpeedUpdated(SKILL_MAP_ID, 1, 0, 1);
+    }
+
+    @Test
+    public void submitFeedback_multipleUsers_broadcastsCorrectCounts() {
+        Mockito.when(collaborationSessionRepository.findById(SESSION_ID))
+                .thenReturn(Optional.of(buildActiveSession()));
+
+        speedFeedbackService.submitFeedback(SESSION_ID, USER_ID, SpeedFeedback.TOO_FAST);
+        speedFeedbackService.submitFeedback(SESSION_ID, OTHER_USER_ID, SpeedFeedback.TOO_SLOW);
+
+        Mockito.verify(webSocketBroadcastService, Mockito.times(1))
+                .broadcastSpeedUpdated(SKILL_MAP_ID, 1, 1, 2);
+    }
+
+    @Test
+    public void submitFeedback_userUpdatesVote_countsReflectUpdate() {
+        Mockito.when(collaborationSessionRepository.findById(SESSION_ID))
+                .thenReturn(Optional.of(buildActiveSession()));
+
+        speedFeedbackService.submitFeedback(SESSION_ID, USER_ID, SpeedFeedback.TOO_FAST);
+        speedFeedbackService.submitFeedback(SESSION_ID, USER_ID, SpeedFeedback.TOO_SLOW);
+
+        Mockito.verify(webSocketBroadcastService, Mockito.times(1))
+                .broadcastSpeedUpdated(SKILL_MAP_ID, 0, 1, 1);
+    }
+
+    @Test
+    public void submitFeedback_okVote_countsInTotalResponses() {
+        Mockito.when(collaborationSessionRepository.findById(SESSION_ID))
+                .thenReturn(Optional.of(buildActiveSession()));
+
+        speedFeedbackService.submitFeedback(SESSION_ID, USER_ID, SpeedFeedback.OK);
+
+        Mockito.verify(webSocketBroadcastService, Mockito.times(1))
+                .broadcastSpeedUpdated(SKILL_MAP_ID, 0, 0, 1);
+    }
+
+    @Test
+    public void submitFeedback_sessionNotActive_throwsForbidden() {
+        Mockito.when(collaborationSessionRepository.findById(SESSION_ID))
+                .thenReturn(Optional.of(buildInactiveSession()));
+
+        assertThrows(ResponseStatusException.class,
+                () -> speedFeedbackService.submitFeedback(SESSION_ID, USER_ID, SpeedFeedback.TOO_FAST));
+    }
+
+    @Test
+    public void submitFeedback_sessionNotFound_throwsNotFound() {
+        Mockito.when(collaborationSessionRepository.findById(SESSION_ID))
+                .thenReturn(Optional.empty());
+
+        assertThrows(ResponseStatusException.class,
+                () -> speedFeedbackService.submitFeedback(SESSION_ID, USER_ID, SpeedFeedback.TOO_FAST));
+    }
+
+    // --- clearSession ---
+
+    @Test
+    public void clearSession_afterVotesSubmitted_broadcastsEmptyCounts() {
+        Mockito.when(collaborationSessionRepository.findById(SESSION_ID))
+                .thenReturn(Optional.of(buildActiveSession()));
+
+        speedFeedbackService.submitFeedback(SESSION_ID, USER_ID, SpeedFeedback.TOO_FAST);
+        speedFeedbackService.clearSession(SESSION_ID);
+        speedFeedbackService.submitFeedback(SESSION_ID, USER_ID, SpeedFeedback.TOO_FAST);
+
+        // after clear, next submission should broadcast as if starting fresh
+        Mockito.verify(webSocketBroadcastService, Mockito.times(2))
+                .broadcastSpeedUpdated(SKILL_MAP_ID, 1, 0, 1);
+    }
+}


### PR DESCRIPTION
quick summary of everything that was implemented:

- SpeedFeedback enum (TOO_FAST, TOO_SLOW, OK)
- SpeedFeedbackPutDTO for the request body
- SpeedUpdatedMessageDTO for the WebSocket broadcast
- SpeedFeedbackService with in-memory ConcurrentHashMap, upsert logic, active session validation, and broadcast
- broadcastSpeedUpdated added to WebSocketBroadcastService
- getSessionById added to CollaborationSessionService
- clearSession hooked into endSession
- SpeedFeedbackController with PUT /sessions/{sessionId}/speed
- Service and controller tests